### PR TITLE
authenticated? should return false for a user with nil digestのテストを移す

### DIFF
--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -71,10 +71,6 @@ class LogoutTest < Logout
     delete logout_path
     assert_redirected_to root_url
   end
-
-  test 'authenticated? should return false for a user with nil digest' do
-    assert_not @user.authenticated?('')
-  end
 end
 
 class RememberingTest < UsersLogin

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -62,4 +62,8 @@ class UserTest < ActiveSupport::TestCase
     @user.password = @user.password_confirmation = 'a' * 5
     assert_not @user.valid?
   end
+
+  test 'authenticated? should return false for a user with nil digest' do
+    assert_not @user.authenticated?('')
+  end
 end


### PR DESCRIPTION
記憶ダイジェストを持たないユーザーを用意し（setupメソッドで定義した@userインスタンス変数ではtrueになります）、続いてauthenticated?を呼び出します（[リスト 9.18](https://railstutorial.jp/chapters/advanced_login?version=7.0#code-test_authenticated_invalid_token)）。
この中で、記憶トークンを空欄のままにしていることにご注目ください。記憶トークンが使われる前にエラーが発生するので、記憶トークンはどんな値でも構わないのです。