### PR TITLE
Updating users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,9 @@ ruby '3.2.8'
 gem 'bcrypt',          '3.1.18'
 gem 'bootsnap',        '1.16.0', require: false
 gem 'bootstrap-sass',  '3.4.1'
+gem 'bootstrap-will_paginate', '1.0.0'
 gem 'concurrent-ruby', '1.3.4'
+gem 'faker',           '3.3.0'
 gem 'importmap-rails', '1.1.5'
 gem 'jbuilder',        '2.11.5'
 gem 'puma',            '5.6.8'
@@ -16,6 +18,7 @@ gem 'sprockets-rails', '3.4.2'
 gem 'sqlite3',         '1.6.1'
 gem 'stimulus-rails',  '1.2.1'
 gem 'turbo-rails',     '1.4.0'
+gem 'will_paginate',   '3.3.1'
 
 group :development, :test do
   gem 'debug', '1.7.1', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
+    bootstrap-will_paginate (1.0.0)
+      will_paginate
     builder (3.3.0)
     capybara (3.38.0)
       addressable
@@ -102,6 +104,8 @@ GEM
     diff-lcs (1.6.1)
     erubi (1.13.1)
     execjs (2.10.0)
+    faker (3.3.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.17.1-aarch64-linux-gnu)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
@@ -346,6 +350,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.37)
@@ -363,9 +368,11 @@ DEPENDENCIES
   bcrypt (= 3.1.18)
   bootsnap (= 1.16.0)
   bootstrap-sass (= 3.4.1)
+  bootstrap-will_paginate (= 1.0.0)
   capybara (= 3.38.0)
   concurrent-ruby (= 1.3.4)
   debug (= 1.7.1)
+  faker (= 3.3.0)
   guard (= 2.18.0)
   guard-minitest (= 2.4.6)
   importmap-rails (= 1.1.5)
@@ -388,6 +395,7 @@ DEPENDENCIES
   turbo-rails (= 1.4.0)
   web-console (= 4.2.0)
   webdrivers (= 5.2.0)
+  will_paginate (= 3.3.1)
 
 RUBY VERSION
    ruby 3.2.8p263

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -212,3 +212,15 @@ input {
 .dropdown-menu.active {
   display: block;
 }
+
+/* users index */
+
+.users {
+  list-style: none;
+  margin: 0;
+  li {
+    overflow: auto;
+    padding: 10px 0;
+    border-bottom: 1px solid $gray-lighter;
+  }
+}

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,10 +4,11 @@ class SessionsController < ApplicationController
   def create
     @user = User.find_by(email: params[:session][:email].downcase)
     if @user&.authenticate(params[:session][:password])
+      forwarding_url = session[:forwarding_url]
       reset_session
       params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
       log_in @user
-      redirect_to @user
+      redirect_to forwarding_url || @user
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new', status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,7 @@
 class UsersController < ApplicationController
+  before_action :logged_in_user, only: %i[edit update]
+  before_action :correct_user, only: %i[edit update]
+
   def show
     @user = User.find(params[:id])
   end
@@ -19,12 +22,9 @@ class UsersController < ApplicationController
     end
   end
 
-  def edit
-    @user = User.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @user = User.find(params[:id])
     if @user.update(user_params)
       flash[:success] = 'Profile updated'
       redirect_to @user
@@ -37,5 +37,21 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+  # beforeフィルタ
+
+  # ログイン済みユーザーかどうか確認
+  def logged_in_user
+    return if logged_in?
+
+    store_location
+    flash[:danger] = 'Please log in.'
+    redirect_to login_url, status: :see_other
+  end
+
+  # 正しいユーザーかどうか確認
+  def correct_user
+    @user = User.find(params[:id])
+    redirect_to(root_url, status: :see_other) unless current_user?(@user)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,14 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: %i[edit update]
+  before_action :logged_in_user, only: %i[edit index update destroy]
   before_action :correct_user, only: %i[edit update]
+  before_action :admin_user, only: :destroy
 
   def show
     @user = User.find(params[:id])
+  end
+
+  def index
+    @users = User.paginate(page: params[:page])
   end
 
   def new
@@ -33,6 +38,12 @@ class UsersController < ApplicationController
     end
   end
 
+  def destroy
+    User.find(params[:id]).destroy
+    flash[:success] = 'User deleted'
+    redirect_to users_url, status: :see_other
+  end
+
   private
 
   def user_params
@@ -53,5 +64,10 @@ class UsersController < ApplicationController
   def correct_user
     @user = User.find(params[:id])
     redirect_to(root_url, status: :see_other) unless current_user?(@user)
+  end
+
+  # 管理者かどうか確認
+  def admin_user
+    redirect_to(root_url, status: :see_other) unless current_user.admin?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,20 @@ class UsersController < ApplicationController
     end
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      flash[:success] = 'Profile updated'
+      redirect_to @user
+    else
+      render 'edit', status: :unprocessable_entity
+    end
+  end
+
   private
 
   def user_params

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -10,7 +10,7 @@ module SessionsHelper
   def current_user
     if (user_id = session[:user_id])
       user = User.find_by(id: user_id)
-      @current_user = user if user && session[:session_token] == user.remember_digest
+      @current_user = user if user && session[:session_token] == user.session_token
     elsif (user_id = cookies.encrypted[:user_id])
       user = User.find_by(id: user_id)
       if user && user.authenticated?(cookies[:remember_token])
@@ -44,5 +44,14 @@ module SessionsHelper
     forget(current_user)
     reset_session
     @current_user = nil
+  end
+
+  def current_user?(user)
+    user && user == current_user
+  end
+
+  # アクセスしようとしたURLを保存する
+  def store_location
+    session[:forwarding_url] = request.original_url if request.get?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX },
                     uniqueness: true
   has_secure_password
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :password, presence: true, length: { minimum: 6 }, allow_nil: true
 
   # 渡された文字列のハッシュ値を返す
   def self.digest(string)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,7 +15,7 @@
             <li><%= link_to "Home", root_path %></li>
             <li><%= link_to "Help", help_path %></li>
             <% if logged_in? %>
-              <li><%= link_to "Users", '#' %></li>
+              <li><%= link_to "Users", users_path %></li>
               <li class="dropdown">
                 <a href="#" id="account" class="dropdown-toggle">
                   Account <b class="caret"></b>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,7 +22,7 @@
                 </a>
                 <ul id="dropdown-menu" class="dropdown-menu">
                   <li><%= link_to "Profile", current_user %></li>
-                  <li><%= link_to "Settings", '#' %></li>
+                  <li><%= link_to "Settings", edit_user_path(current_user) %></li>
                   <li class="divider"></li>
                   <li><%= link_to "Log out", logout_path, data: {"turbo-method": :delete} %></li>
                 </ul>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(model: @user) do |f| %>
+  <%= render 'shared/error_messages' %>
+
+  <%= f.label :name %>
+  <%= f.text_field :name, class: 'form-control' %>
+  
+  <%= f.label :email %>
+  <%= f.email_field :email, class: 'form-control' %>
+
+  <%= f.label :password %>
+  <%= f.password_field :password, class: 'form-control' %>
+
+  <%= f.label :password_confirmation, "Confirmation" %>
+  <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, "Edit user") %>
+<% provide(:button_text, 'Save changes') %>
+<h1>Update your account</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= render 'form' %>
+    <div class="gravatar_edit">
+      <%= gravatar_for @user %>
+      <a href="https://gravatar.com/emails" target="_blank" rel="noopener">change</a>
+    </div>
+  </div>
+</div> 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,23 +1,9 @@
 <% provide(:title, "Sign up") %>
+<% provide(:button_text, 'Create my account') %>
 <h1>Sign up</h1>
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(model: @user) do |f| %>
-      <%= render 'shared/error_messages' %>
-      <%= f.label :name %>
-      <%= f.text_field :name, class: 'form-control' %>
-      
-      <%= f.label :email %>
-      <%= f.email_field :email, class: 'form-control' %>
-
-      <%= f.label :password %>
-      <%= f.password_field :password, class: 'form-control' %>
-
-      <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation, class: 'form-control' %>
-
-      <%= f.submit "Create my account", class: "btn btb-primary" %>
-    <% end %>
+   <%= render 'form' %>
   </div>
 </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_02_003928) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_05_015926) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_02_003928) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.string "remember_digest"
+    t.boolean "admin"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,17 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+# メインのサンプルユーザーを1人作成する
+User.create!(name: 'Example User',
+             email: 'example@railstutorial.org',
+             password: 'foobar',
+             password_confirmation: 'foobar',
+             admin: true)
+
+# 追加のユーザーをまとめて生成する
+99.times do |n|
+  name  = Faker::Name.name
+  email = "example-#{n + 1}@railstutorial.org"
+  password = 'password'
+  User.create!(name: name,
+               email: email,
+               password: password,
+               password_confirmation: password)
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,8 +1,25 @@
 require 'test_helper'
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+    @other_user = users(:archer)
+  end
+
   test 'should get new' do
     get signup_path
     assert_response :success
+  end
+
+  test 'should redirect edit when not logged in' do
+    get edit_user_path(@user)
+    assert_not flash.empty?
+    assert_redirected_to login_url
+  end
+
+  test 'should redirect update when not logged in' do
+    patch user_path(@user), params: { user: { name: @user.name, email: @user.email } }
+    assert_not flash.empty?
+    assert_redirected_to login_url
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -22,4 +22,37 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_not flash.empty?
     assert_redirected_to login_url
   end
+
+  test 'should redirect index when not logged in' do
+    get users_path
+    assert_redirected_to login_url
+  end
+
+  test 'should not allow the admin attribute to be edited via the web' do
+    log_in_as(@other_user)
+    assert_not @other_user.admin?
+    patch user_path(@other_user), params: {
+      user: { password: @other_user.password,
+              password_confirmation: @other_user.password,
+              admin: true }
+    }
+    assert_not @other_user.reload.admin?
+  end
+
+  test 'should redirect destroy when not logged in' do
+    assert_no_difference 'User.count' do
+      delete user_path(@user)
+    end
+    assert_response :see_other
+    assert_redirected_to login_url
+  end
+
+  test 'should redirect destroy when logged in as a non-admin' do
+    log_in_as(@other_user)
+    assert_no_difference 'User.count' do
+      delete user_path(@user)
+    end
+    assert_response :see_other
+    assert_redirected_to root_url
+  end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,3 +2,8 @@ michael:
  name: michael Example
  email: michael@example.com
  password_digest: <%= User.digest('password') %>
+
+archer:
+  name: archer Example
+  email: archer@example.com
+  password_digest: <%= User.digest('password') %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,9 +1,27 @@
 michael:
- name: michael Example
- email: michael@example.com
- password_digest: <%= User.digest('password') %>
+  name: Michael Example
+  email: michael@example.com
+  password_digest: <%= User.digest('password') %>
+  admin: true
 
 archer:
-  name: archer Example
-  email: archer@example.com
+  name: Sterling Archer
+  email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
+
+lana:
+  name: Lana Kane
+  email: hands@example.gov
+  password_digest: <%= User.digest('password') %>
+
+malory:
+  name: Malory Archer
+  email: boss@example.gov
+  password_digest: <%= User.digest('password') %>
+
+<% 30.times do |n| %>
+user_<%= n %>:
+  name:  <%= "User #{n}" %>
+  email: <%= "user-#{n}@example.com" %>
+  password_digest: <%= User.digest('password') %>
+<% end %>

--- a/test/integration/user_edit_test.rb
+++ b/test/integration/user_edit_test.rb
@@ -6,6 +6,7 @@ class UserEditTest < ActionDispatch::IntegrationTest
   end
 
   test 'unsuccessful edit' do
+    log_in_as(@user)
     get edit_user_path(@user)
     assert_template 'users/edit'
     patch user_path(@user),
@@ -13,9 +14,10 @@ class UserEditTest < ActionDispatch::IntegrationTest
     assert_template 'users/edit'
   end
 
-  test 'successful edit' do
+  test 'successful edit with friendly forwarding' do
     get edit_user_path(@user)
-    assert_template 'users/edit'
+    log_in_as(@user)
+    assert_redirected_to edit_user_url(@user)
     name = 'Foo Bar'
     email = 'foo@bar.com'
     patch user_path(@user), params: { user: { name: name, email: email, password: '', password_confirmation: '' } }

--- a/test/integration/user_edit_test.rb
+++ b/test/integration/user_edit_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class UserEditTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+  end
+
+  test 'unsuccessful edit' do
+    get edit_user_path(@user)
+    assert_template 'users/edit'
+    patch user_path(@user),
+          params: { user: { name: '', email: 'foo@invalid', password: 'foo', password_confirmation: 'bar' } }
+    assert_template 'users/edit'
+  end
+
+  test 'successful edit' do
+    get edit_user_path(@user)
+    assert_template 'users/edit'
+    name = 'Foo Bar'
+    email = 'foo@bar.com'
+    patch user_path(@user), params: { user: { name: name, email: email, password: '', password_confirmation: '' } }
+    assert_not flash.empty?
+    assert_redirected_to @user
+    @user.reload
+    assert_equal name, @user.name
+    assert_equal email, @user.email
+  end
+end


### PR DESCRIPTION
### 本章のまとめ

- ユーザーは、編集フォームからPATCHリクエストをupdateアクションに対して送信し、情報を更新する
- Strong Parametersを使うことで、Web経由で安全にデータを更新できるようになる
- beforeフィルターを使うと、特定のアクションが実行される直前にメソッドを呼び出せる
- beforeフィルターを使って、認可（アクセス制御）を実現した
- 認可に対するテストでは、特定のHTTPリクエストを直接送信するシンプルなテストと、ブラウザの操作をシミュレーションする複雑なテスト（統合テスト）の2つを利用した
- フレンドリーフォワーディングとは、ログイン成功時に元々表示したかったページに転送する機能である
- ユーザー一覧ページでは、すべてのユーザーをページ単位に分割して表示する
- rails db:seedコマンドは、db/seeds.rbにあるサンプルデータをデータベースに流し込む
- render @usersを実行すると、自動的に_user.html.erbパーシャルを参照し、各ユーザーをコレクションとして表示する
- boolean型のadmin属性をUserモデルに追加すると、admin?という論理オブジェクトを返すメソッドが自動的に追加される
- 管理者が削除リンクをクリックすると、DELETEリクエストがdestroyアクションに送信され、該当するユーザーが削除される
- fixtureファイル内でERBを使うと、テストユーザーを多数作成できる