### PR TITLE
Add password reset

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,0 +1,60 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, only: %i[edit update]
+  before_action :valid_user, only: %i[edit update]
+  before_action :check_expiration, only: %i[edit update]
+  def new; end
+
+  def create
+    @user = User.find_by(email: params[:password_reset][:email].downcase)
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = 'Email sent with password reset instructions'
+      redirect_to root_url
+    else
+      flash.now[:danger] = 'Email address not found'
+      render 'new', status: :unprocessable_entity
+    end
+  end
+
+  def edit; end
+
+  def update
+    if params[:user][:password].empty?
+      @user.errors.add(:password, "can't be empty")
+      render 'edit', status: :unprocessable_entity
+    elsif @user.update(user_params)
+      reset_session
+      log_in @user
+      @user.update_attribute(:reset_digest, nil)
+      flash[:success] = 'Password has been reset.'
+      redirect_to @user
+    else
+      render 'edit', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:password, :password_confirmation)
+  end
+
+  # before filters
+  def get_user
+    @user = User.find_by(email: params[:email])
+  end
+
+  def valid_user
+    return if @user&.activated? && @user.authenticated?(:reset, params[:id])
+
+    redirect_to root_url
+  end
+
+  def check_expiration
+    return unless @user.password_reset_expired?
+
+    flash[:danger] = 'Password reset has expired.'
+    redirect_to new_password_reset_url
+  end
+end

--- a/app/helpers/pasword_resets_helper.rb
+++ b/app/helpers/pasword_resets_helper.rb
@@ -1,0 +1,2 @@
+module PaswordResetsHelper
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,9 +4,8 @@ class UserMailer < ApplicationMailer
     mail to: user.email, subject: 'Account activation'
   end
 
-  def password_reset
-    @greeting = 'Hi'
-
-    mail to: 'to@example.org'
+  def password_reset(user)
+    @user = user
+    mail to: user.email, subject: 'Password reset'
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
 
   before_save { self.email = email.downcase }
   before_create :create_activation_digest
@@ -59,6 +59,21 @@ class User < ApplicationRecord
   # 有効化用のメールを送信する
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  # パスワード再設定の属性を設定する
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update_columns(reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now)
+  end
+
+  # パスワード再設定のメールを送信する
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  def password_reset_expired?
+    reset_sent_at < 2.hours.ago
   end
 
   private

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,0 +1,20 @@
+<% provide(:title, 'Reset password') %>
+<h1>Reset password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: password_reset_path(params[:id]), scope: :password_reset) do |f| %>
+      <%= render 'shared/error_messages' %>
+
+      <%= hidden_field_tag :email, @user.email %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.label :password_confirmation, 'Confirmation' %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
+
+      <%= f.submit 'Update password', class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,0 +1,13 @@
+<% provide(:title, 'Forgot password') %>
+<h1>Forgot password</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: password_resets_path, scope: :password_reset) do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.submit "Submit", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -9,6 +9,7 @@
       <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
+      <%= link_to "(forgot password)", new_password_reset_path %>
       <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,5 +1,12 @@
-<h1>User#password_reset</h1>
+<h1>Password reset</h1>
+
+<p>To reset your password click the link below:</p>
+
+<%= link_to 'Reset password', edit_password_reset_url(@user.reset_token, email: @user.email) %>
+
+<p>This link will expire in two hours.</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+  If you did not request your password to be reset, please ignore this email and
+  your password will stay as it is.
 </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   delete '/logout', to: 'sessions#destroy'
   resources :users
   resources :account_activations, only: [:edit]
+  resources :password_resets, only: %i[new create edit update]
 end

--- a/db/migrate/20250606025822_add_reset_to_users.rb
+++ b/db/migrate/20250606025822_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_05_053413) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_06_025822) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -22,6 +22,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_05_053413) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -36,7 +36,7 @@ user_<%= n %>:
   activated_at: <%= Time.zone.now %>
 <% end %>
 
-inacctive:
+inactive:
   name: Inactive User
   email: inactive@example.com
   password_digest: <%= User.digest('password') %>

--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -1,0 +1,121 @@
+require 'test_helper'
+
+class PasswordResets < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
+end
+
+class ForgotPasswordFormTest < PasswordResets
+  test 'password reset path' do
+    get new_password_reset_path
+    assert_template 'password_resets/new'
+    assert_select 'input[name=?]', 'password_reset[email]'
+  end
+
+  test 'reset path with invalid email' do
+    post password_resets_path, params: { password_reset: { email: '' } }
+    assert_response :unprocessable_entity
+    assert_not flash.empty?
+    assert_template 'password_resets/new'
+  end
+end
+
+class PasswordResetForm < PasswordResets
+  def setup
+    super
+    @user = users(:michael)
+    post password_resets_path,
+         params: { password_reset: { email: @user.email } }
+    @reset_user = assigns(:user)
+  end
+end
+
+class PasswordFormTest < PasswordResetForm
+  test 'reset with valid email' do
+    assert_not_equal @user.reset_digest, @reset_user.reset_digest
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    assert_not flash.empty?
+    assert_redirected_to root_url
+  end
+
+  test 'reset with wrong email' do
+    get edit_password_reset_path(@reset_user.reset_token, email: '')
+    assert_redirected_to root_url
+  end
+
+  test 'reset with inactive user' do
+    @reset_user.toggle!(:activated)
+    get edit_password_reset_path(@reset_user.reset_token,
+                                 email: @reset_user.email)
+    assert_redirected_to root_url
+  end
+
+  test 'reset with right email but wrong token' do
+    get edit_password_reset_path('wrong token', email: @reset_user.email)
+    assert_redirected_to root_url
+  end
+
+  test 'reset with right email and right token' do
+    get edit_password_reset_path(@reset_user.reset_token,
+                                 email: @reset_user.email)
+    assert_template 'password_resets/edit'
+    assert_select 'input[name=email][type=hidden][value=?]', @reset_user.email
+  end
+end
+
+class PasswordUpdateTest < PasswordResetForm
+  test 'update with invalid password and confirmation' do
+    patch password_reset_path(@reset_user.reset_token),
+          params: { email: @reset_user.email,
+                    user: { password: 'foobaz',
+                            password_confirmation: 'barquux' } }
+    assert_select 'div#error_explanation'
+  end
+
+  test 'update with empty password' do
+    patch password_reset_path(@reset_user.reset_token),
+          params: { email: @reset_user.email,
+                    user: { password: '',
+                            password_confirmation: '' } }
+    assert_select 'div#error_explanation'
+  end
+
+  test 'update with valid password and confirmation' do
+    patch password_reset_path(@reset_user.reset_token),
+          params: { email: @reset_user.email,
+                    user: { password: 'foobaz',
+                            password_confirmation: 'foobaz' } }
+    assert is_logged_in?
+    assert_not flash.empty?
+    assert_redirected_to @reset_user
+  end
+end
+
+class ExpiredToken < PasswordResetForm
+  def setup
+    super
+    # パスワードリセットのトークンを作成する
+    post password_resets_path,
+         params: { password_reset: { email: @user.email } }
+    @reset_user = assigns(:user)
+    # トークンを手動で失効させる
+    @reset_user.update_attribute(:reset_sent_at, 3.hours.ago)
+    # ユーザーのパスワードの更新を試みる
+    patch password_reset_path(@reset_user.reset_token),
+          params: { email: @reset_user.email,
+                    user: { password: 'foobar',
+                            password_confirmation: 'foobar' } }
+  end
+end
+
+class ExpiredTokenTest < ExpiredToken
+  test 'should redirect to the password-reset page' do
+    assert_redirected_to new_password_reset_url
+  end
+
+  test "should include the word 'expired' on the password-reset page" do
+    follow_redirect!
+    assert_match(/expired/i, response.body)
+  end
+end

--- a/test/integration/user_show_test.rb
+++ b/test/integration/user_show_test.rb
@@ -10,7 +10,7 @@ end
 class UserShowTest < UserShow
   test 'should redirect when user not activated' do
     get user_path(@inactive_user)
-    assert_response :see_other
+    assert_response :found
     assert_redirected_to root_url
   end
 

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -16,7 +16,6 @@ class UsersIndexAdmin < UsersIndex
 end
 
 class UsersIndexAdminTest < UsersIndexAdmin
-
   test 'should render the index page' do
     assert_template 'users/index'
   end
@@ -29,9 +28,7 @@ class UsersIndexAdminTest < UsersIndexAdmin
     first_page_of_users = User.where(activated: true).paginate(page: 1)
     first_page_of_users.each do |user|
       assert_select 'a[href=?]', user_path(user), text: user.name
-      unless user == @admin
-        assert_select 'a[href=?]', user_path(user), text: 'delete'
-      end
+      assert_select 'a[href=?]', user_path(user), text: 'delete' unless user == @admin
     end
   end
 
@@ -39,8 +36,8 @@ class UsersIndexAdminTest < UsersIndexAdmin
     assert_difference 'User.count', -1 do
       delete user_path(@non_admin)
     end
-      assert_response :see_other
-      assert_redirected_to users_url
+    assert_response :see_other
+    assert_redirected_to users_url
   end
 
   test 'should display only activated users' do
@@ -49,7 +46,7 @@ class UsersIndexAdminTest < UsersIndexAdmin
     # Railsで最初のページに表示される保証がないので不十分
     User.paginate(page: 1).first.toggle!(:activated)
     # /usersを再度取得して、無効化済みのユーザーが表示されていないことを確かめる
-    get users_path      
+    get users_path
     # 表示されているすべてのユーザーが有効化済みであることを確かめる
     assigns(:users).each do |user|
       assert user.activated?
@@ -57,8 +54,7 @@ class UsersIndexAdminTest < UsersIndexAdmin
   end
 end
 
-class usersNonAdminIndexTest < UsersIndex
-
+class UsersNonAdminIndexTest < UsersIndex
   test 'should not have delete links as non-admin' do
     log_in_as(@non_admin)
     get users_path

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -9,6 +9,8 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
   def password_reset
-    UserMailer.password_reset
+    user = User.first
+    user.reset_token = User.new_token
+    UserMailer.password_reset(user)
   end
 end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -6,10 +6,21 @@ class UserMailerTest < ActionMailer::TestCase
     user.activation_token = User.new_token
     mail = UserMailer.account_activation(user)
     assert_equal 'Account activation', mail.subject
-    assert_equal ['michael@example.com'], mail.to
+    assert_equal [user.email], mail.to
     assert_equal ['user@realdomain.com'], mail.from
-    assert_match user.name, mail.body.encoded
-    assert_match user.activation_token, mail.body.encoded
-    assert_match CGI.escape(user.email), mail.body.encoded
+    assert_match user.name,               mail.body.encoded
+    assert_match user.activation_token,   mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
+  end
+
+  test 'password_reset' do
+    user = users(:michael)
+    user.reset_token = User.new_token
+    mail = UserMailer.password_reset(user)
+    assert_equal 'Password reset', mail.subject
+    assert_equal [user.email], mail.to
+    assert_equal ['user@realdomain.com'], mail.from
+    assert_match user.reset_token,        mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
   end
 end


### PR DESCRIPTION
### 12章のまとめ

- パスワードの再設定はActive Recordオブジェクトではないが、セッションやアカウント有効化の場合と同様に、リソースでモデル化できる
- Railsは、メール送信で扱うAction Mailerのアクションとビューを生成できる
- Action MailerではテキストメールとHTMLメールの両方を利用できる
- メーラーアクションで定義したインスタンス変数は、他のアクションやビューと同様、メーラーのビューから参照できる
- パスワードを再設定させるために、生成したトークンを使って一意のURLを作る
- より安全なパスワード再設定のために、ハッシュ化したトークン（ダイジェスト）を使うこと
- メーラーのテストと統合テストは、どちらもUserメーラーの振舞いを確認するのに便利
- Mailgunを使うとproduction環境からメールを送信できる